### PR TITLE
Kompatibilität mit neuer REX-Loginseite herstellen

### DIFF
--- a/assets/be_password.css
+++ b/assets/be_password.css
@@ -1,3 +1,9 @@
+#rex-page-login .btn-primary {
+    width: auto;
+    min-width: 45%;
+    float: right;
+}
+
 .be_password_cancel {
     float: left !important;
     padding-left: 0;

--- a/assets/javascript/be_password.js
+++ b/assets/javascript/be_password.js
@@ -10,12 +10,12 @@ var BePassHandler = (function () {
         }
         if (undefined == form) {
             $.get(url, function (dat) {
-                $("#rex-js-page-main").html(dat);
+                $("#rex-form-login").html(updateFormElements(dat));
                 applyHandlers("#rex-js-page-main .has-handler");
             });
         } else {
             $.post(url, $(form).serialize(), function (dat) {
-                $("#rex-js-page-main").html(dat);
+                $("#rex-form-login").html(updateFormElements(dat));
                 applyHandlers("#rex-js-page-main .has-handler");
             });
         }
@@ -38,13 +38,13 @@ var BePassHandler = (function () {
         }
         if (undefined == form) {
             $.get(url, function (dat) {
-                $("#rex-js-page-main").html(dat);
+                $("#rex-form-login").html(updateFormElements(dat));
                 applyHandlers("#rex-js-page-main .has-handler");
             });
         } else {
             var pw = $(form).find('input[name="password"]').val();
             $.post(url, {pw: pw}, function (dat) {
-                $("#rex-js-page-main").html(dat);
+                $("#rex-js-page-main").html(updateFormElements(dat));
                 applyHandlers("#rex-js-page-main .has-handler");
             });
         }
@@ -71,6 +71,17 @@ $(function () {
         });
     }
 });
+
+function updateFormElements(content) {
+    content = $(content);
+    // select branding element on current login form and inject into our form
+    content.find(".panel-body").prepend($(".rex-branding", "#rex-form-login"));
+    // if there is no panel heading (R 5.12+), we don’t use ours either
+    if (!$(".panel-heading", "#rex-form-login").length) {
+        content.find(".panel-heading").remove();
+    }
+    return content;
+}
 
 function applyHandlers(selector) {
     var $ = jQuery; // Innerhalb von WP sonst nicht bekannt

--- a/assets/javascript/be_password.js
+++ b/assets/javascript/be_password.js
@@ -15,6 +15,7 @@ var BePassHandler = (function () {
             });
         } else {
             $.post(url, $(form).serialize(), function (dat) {
+                $(".rex-js-login-message").remove();
                 $("#rex-form-login").html(updateFormElements(dat));
                 applyHandlers("#rex-js-page-main .has-handler");
             });
@@ -44,7 +45,7 @@ var BePassHandler = (function () {
         } else {
             var pw = $(form).find('input[name="password"]').val();
             $.post(url, {pw: pw}, function (dat) {
-                $("#rex-js-page-main").html(updateFormElements(dat));
+                $("#rex-form-login").html(updateFormElements(dat));
                 applyHandlers("#rex-js-page-main .has-handler");
             });
         }

--- a/views/form.php
+++ b/views/form.php
@@ -3,15 +3,16 @@ if ($success != '') {
     echo '<div class="rex-js-login-message">' . rex_view::success($success) . "</div>";
 }
 
-if ($error != '') {
-    echo '<div class="rex-js-login-message">' . rex_view::error($error) . "</div>";
-}
-
 if ($success == '') {
 
     $email = rex_request('email', 'string');
 
     $content = '';
+
+    if ($error != '') {
+        $content .= '<div class="rex-js-login-message">' . rex_view::error($error) . "</div>";
+    }
+
     $content .= '<fieldset>';
 
     $formElements = [];
@@ -40,11 +41,11 @@ if ($success == '') {
 
     $formElements = [];
     $n = [];
-    $n['field'] = '<button class="btn btn-primary" type="submit">Senden</button>';
+    $n['field'] = '<a class="btn btn-link be_password_cancel" href="' . rex_url::currentBackendPage() . '">Abbrechen</a>';
     $formElements[] = $n;
 
     $n = [];
-    $n['field'] = '<a class="btn btn-link be_password_cancel" href="' . rex_url::currentBackendPage() . '">Abbrechen</a>';
+    $n['field'] = '<button class="btn btn-primary btn-block" type="submit">Senden</button>';
     $formElements[] = $n;
 
     $fragment = new rex_fragment();

--- a/views/form.php
+++ b/views/form.php
@@ -1,17 +1,30 @@
 <?php
-if ($success != '') {
-    echo '<div class="rex-js-login-message">' . rex_view::success($success) . "</div>";
+// check for new login page that comes with fragment for background image
+$isNewLoginPage = file_exists(rex_path::core('fragments/core/login_background.php'));
+
+$email = rex_request('email', 'string');
+$content = '';
+
+
+if (!empty($success)) {
+    $successMessage = '<div class="rex-js-login-message">' . rex_view::success($success) . '</div>';
 }
 
-if ($success == '') {
+if (!empty($error)) {
+    $errorMessage = '<div class="rex-js-login-message">' . rex_view::error($error) . '</div>';
+}
 
-    $email = rex_request('email', 'string');
+if (!$isNewLoginPage) {
+    echo $successMessage;
+    echo $errorMessage;
+}
+else {
+    $content .= $successMessage;
+    $content .= $errorMessage;
+}
 
-    $content = '';
 
-    if ($error != '') {
-        $content .= '<div class="rex-js-login-message">' . rex_view::error($error) . "</div>";
-    }
+if (empty($success)) {
 
     $content .= '<fieldset>';
 
@@ -51,24 +64,27 @@ if ($success == '') {
     $fragment = new rex_fragment();
     $fragment->setVar('elements', $formElements, false);
     $buttons = $fragment->parse('core/form/submit.php');
+}
+
+if (!(!empty($success) && !$isNewLoginPage)) {
 
     $fragment = new rex_fragment();
     $fragment->setVar('title', 'Passwort zurücksetzen', false);
     $fragment->setVar('body', $content, false);
     $fragment->setVar('buttons', $buttons, false);
     $content = $fragment->parse('core/page/section.php');
-
-    $content = '
-        <form class="has-handler" data-handler="submit:BePassHandler:showForm" method="post">
-            ' . $content . '
-        </form>
-        <script>
-            (function() {
-                var inputField = $("#be_password_email_input");
-                var initialValue = inputField.val();
-                inputField.val("").val(initialValue).focus(); // focus with trailing caret
-            }());
-        </script>';
-
-    echo $content;
 }
+
+$content = '
+    <form class="has-handler" data-handler="submit:BePassHandler:showForm" method="post">
+        ' . $content . '
+    </form>
+    <script>
+        (function() {
+            var inputField = $("#be_password_email_input");
+            var initialValue = inputField.val();
+            inputField.val("").val(initialValue).focus(); // focus with trailing caret
+        }());
+    </script>';
+
+echo $content;

--- a/views/reset.php
+++ b/views/reset.php
@@ -1,17 +1,31 @@
 <?php
-if ($success != '') {
-    echo '<div class="rex-js-login-message">' . rex_view::success($success) . "</div>";
+// check for new login page that comes with fragment for background image
+$isNewLoginPage = file_exists(rex_path::core('fragments/core/login_background.php'));
+
+$email = rex_request('email', 'string');
+$content = '';
+
+
+if (!empty($success)) {
+    $successMessage = '<div class="rex-js-login-message">' . rex_view::success($success) . '</div>';
 }
 
-if ($error != '') {
-    echo '<div class="rex-js-login-message">' . rex_view::error($error) . "</div>";
+if (!empty($error)) {
+    $errorMessage = '<div class="rex-js-login-message">' . rex_view::error($error) . '</div>';
 }
 
-if ($success == '' || $showForm == true) {
+if (!$isNewLoginPage) {
+    echo $successMessage;
+    echo $errorMessage;
+}
+else {
+    $content .= $successMessage;
+    $content .= $errorMessage;
+}
 
-    $email = rex_request('email', 'string');
 
-    $content = '';
+if (empty($success) || $showForm === true) {
+
     $content .= '<fieldset>';
 
     $formElements = [];
@@ -50,22 +64,25 @@ if ($success == '' || $showForm == true) {
     $fragment = new rex_fragment();
     $fragment->setVar('elements', $formElements, false);
     $buttons = $fragment->parse('core/form/submit.php');
+}
+
+if (!(!empty($success) && !$isNewLoginPage) || $showForm === true) {
 
     $fragment = new rex_fragment();
     $fragment->setVar('title', 'Neues Passwort festlegen', false);
     $fragment->setVar('body', $content, false);
     $fragment->setVar('buttons', $buttons, false);
     $content = $fragment->parse('core/page/section.php');
-
-    $content = '
-        <form class="has-handler" data-handler="submit:BePassHandler:showReset" data-token="' . $token . '" method="post">
-            ' . $content . '
-        </form>
-        <script>
-            (function() {
-                $("#be_password_password_input").focus();
-            }());
-        </script>';
-
-    echo $content;
 }
+
+$content = '
+    <form class="has-handler" data-handler="submit:BePassHandler:showReset" data-token="' . $token . '" method="post">
+        ' . $content . '
+    </form>
+    <script>
+        (function() {
+            $("#be_password_password_input").focus();
+        }());
+    </script>';
+
+echo $content;


### PR DESCRIPTION
fixes #19 

Anmerkungen:

- Success- und Error-Message werden auf der alten Login-Seite _oberhalb_ der Box ausgegeben, in der neuen Login-Seite _innerhalb_ der Box.
- Innerhalb des JS werden die Formularseiten per AJAX verarbeitet und auf der geöffneten Login-Seite ausgetauscht. Dieser Austausch passiert nach Anpassungen nun etwas weiter innen, also tiefer im DOM-Tree, damit nicht »zuviel« ausgetauscht wird (`#rex-form-login` statt `#rex-js-page-main`).
- Vorm Austausch der Formulare wird geprüft, ob es ein Hintergrundbild-Elemente gibt. Wenn ja, wird es mit reingeholt, damit es beim Austausch nicht verloren geht (`updateFormElements()`).
- Um zu unterscheiden, ob wir es mit der alten oder der neuen Login-Seite zu tun haben, prüfe ich, ob das neue Hintergrund-Fragment vorhanden ist (`file_exists(rex_path::core('fragments/core/login_background.php'))`). Dies fand ich sinnvoller, als es an der REDAXO-Version festzumachen (`rex_version::compare()`), weil die Anpassungen damit schon jetzt mit dem master-Branch funktionieren und wir nicht wissen, wann REX 5.12 mit der neuen Login-Page erscheint.

### Flow bei alter Login-Seite:

<img width="570" alt="Screenshot 2020-10-10 at 11 56 44" src="https://user-images.githubusercontent.com/1297466/95652298-5803b980-0af0-11eb-9793-a1048edc6172.png">
<img width="469" alt="Screenshot 2020-10-10 at 11 56 55" src="https://user-images.githubusercontent.com/1297466/95652299-59cd7d00-0af0-11eb-9b33-d0c8f79153f7.png">
<img width="462" alt="Screenshot 2020-10-10 at 11 57 08" src="https://user-images.githubusercontent.com/1297466/95652300-5a661380-0af0-11eb-9e78-da49c43b42bf.png">
<img width="462" alt="Screenshot 2020-10-10 at 11 58 08" src="https://user-images.githubusercontent.com/1297466/95652301-5afeaa00-0af0-11eb-8a3b-7778e1dc44c2.png">
<img width="457" alt="Screenshot 2020-10-10 at 11 58 32" src="https://user-images.githubusercontent.com/1297466/95652303-5b974080-0af0-11eb-9465-7624c5aa3352.png">
<img width="444" alt="Screenshot 2020-10-10 at 11 58 41" src="https://user-images.githubusercontent.com/1297466/95652304-5b974080-0af0-11eb-90c0-1302b2d01c7c.png">
<img width="472" alt="Screenshot 2020-10-10 at 11 58 54" src="https://user-images.githubusercontent.com/1297466/95652306-5c2fd700-0af0-11eb-9bf6-053898daf0b5.png">

### Flow bei neuer Login-Seite:

<img width="468" alt="Screenshot 2020-10-10 at 11 40 50" src="https://user-images.githubusercontent.com/1297466/95652319-6b168980-0af0-11eb-895a-824c24526f16.png">
<img width="458" alt="Screenshot 2020-10-10 at 11 41 03" src="https://user-images.githubusercontent.com/1297466/95652325-6eaa1080-0af0-11eb-9bbb-5cf95b064249.png">
<img width="459" alt="Screenshot 2020-10-10 at 11 41 18" src="https://user-images.githubusercontent.com/1297466/95652326-6f42a700-0af0-11eb-8b61-1420fa939814.png">
<img width="461" alt="Screenshot 2020-10-10 at 11 41 35" src="https://user-images.githubusercontent.com/1297466/95652327-6fdb3d80-0af0-11eb-8054-19ff3e85dfa4.png">
<img width="452" alt="Screenshot 2020-10-10 at 11 42 15" src="https://user-images.githubusercontent.com/1297466/95652328-7073d400-0af0-11eb-8369-d2cf6cef1e87.png">
<img width="470" alt="Screenshot 2020-10-10 at 11 53 20" src="https://user-images.githubusercontent.com/1297466/95652330-7073d400-0af0-11eb-9bfa-5a94a975ba07.png">
<img width="507" alt="Screenshot 2020-10-10 at 11 53 32" src="https://user-images.githubusercontent.com/1297466/95652331-710c6a80-0af0-11eb-89fc-6bf5c165288c.png">

