### PR TITLE
SQL-Abfragen überarbeitet

### DIFF
--- a/lib/Controller/DefaultController.php
+++ b/lib/Controller/DefaultController.php
@@ -85,7 +85,7 @@ class DefaultController
                         $email = $db->getValue('email');
                         // Entferne alle bisherigen reset-tokens für diesen user
                         $db->setTable(rex::getTable('be_password'));
-                        $db->setWhere('usewr_id = :uid', ['uid' => $user_id]);
+                        $db->setWhere('user_id = :uid', ['uid' => $user_id]);
                         $db->delete();
                         // Erzeuge neuen Token
                         try {

--- a/update.php
+++ b/update.php
@@ -1,5 +1,7 @@
 <?php
 
+/** @var rex_addon $this */
+
 // Rename table from user_passwordreset to be_password for version 3.0.0+
 if (version_compare($this->getVersion(), '3.0.0', '<')) {
     $oldTableName = rex::getTable('user_passwordreset');


### PR DESCRIPTION
Kern der Aktion: SQL-Abfragen so umbauen, dass Abfragen nicht ausgeschrieben werden (z.B. `'SELECT * FROM rex_user WHERE email=?'`, sondern durch abgesicherte Methoden aus rex_sql entstehen.

Zugleich einheitlich Tabellennamen durch rex:.setTable er mittelt anstelle ausgeschriebener Prefixe (`rex_...`)

Beifang durch RexStan: in update.php den Datentyp von $this (rex_Addon) angegeben.